### PR TITLE
Interoute support (ServiceUrl is https://myservices.interoute.com/myservices/api/vdc)

### DIFF
--- a/src/CloudStack.Net/CloudStackAPIProxy.cs
+++ b/src/CloudStack.Net/CloudStackAPIProxy.cs
@@ -37,7 +37,6 @@ namespace CloudStack.Net
         private CloudStackAPIProxy(string serviceUrl)
         {
             if (String.IsNullOrEmpty(serviceUrl)) { throw new ArgumentNullException(nameof(serviceUrl)); }
-            if (!serviceUrl.EndsWith("/api", StringComparison.Ordinal)) { throw new ArgumentException(nameof(serviceUrl), $"Expected Service Url to end with /api - it is {serviceUrl}"); }
 
             ServiceUrl = serviceUrl;
         }


### PR DESCRIPTION
Removed check that serviceUrl ends with /api since it doesn't hold for Interoute, where it is https://myservices.interoute.com/myservices/api/vdc