### PR TITLE
Consider upgrading to .net standard?

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -34,7 +34,7 @@ function Invoke-MSBuild($solution, $version, $customLogger)
 
 function Invoke-NuGetPackProj($csproj)
 {
-    nuget pack -Prop Configuration=Release -Symbols $csproj
+    dotnet pack -c Release $csproj
 }
 
 function Invoke-NuGetPackSpec($nuspec, $version)

--- a/src/CloudStack.Net/CloudStack.Net.csproj
+++ b/src/CloudStack.Net/CloudStack.Net.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net471</TargetFramework>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -14,7 +14,7 @@
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="7.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Generated\" />

--- a/src/CloudStack.Net/CloudStack.Net.nuspec
+++ b/src/CloudStack.Net/CloudStack.Net.nuspec
@@ -14,6 +14,6 @@
 	</dependencies>
   </metadata>
   <files>
-	<file src="bin\Release\net471\CloudStack.Net.dll" target="lib\net45" />
+	<file src="bin\Release\netstandard2.0\CloudStack.Net.dll" target="lib\netstandard2.0" />
   </files>
 </package>

--- a/test/CloudStack.Net.Tests/CloudStack.Net.Tests.csproj
+++ b/test/CloudStack.Net.Tests/CloudStack.Net.Tests.csproj
@@ -36,18 +36,15 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Moq, Version=4.2.1510.2205, Culture=neutral, PublicKeyToken=69f491c39445e920, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Moq.4.2.1510.2205\lib\net40\Moq.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=7.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Newtonsoft.Json.7.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="Shouldly, Version=2.6.0.0, Culture=neutral, PublicKeyToken=6042cbcb05cbc941, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\Shouldly.2.6.0\lib\net40\Shouldly.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
+    <PackageReference Include="Moq" Version="4.7.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="Shouldly" Version="2.8.0">
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
     <Reference Include="System" />
   </ItemGroup>
   <Choose>


### PR DESCRIPTION
My recent project in .NET Core hit problems with current version of CloudStack.Net, which isn't offering netstandard package. I made this simple PR. It's just a POC that upgrading should be easy.

Feel free to take, edit or make one on your own. I'm not familiar with the CI system used here, so I made some quick'n'dirty fixes. Some deps are upgraded to the minimum version that supports .net standard.

Tests passed.